### PR TITLE
fix: rename CId_GetSessionsIDs → CId_GetSessionIDs to match PTSL proto enum

### DIFF
--- a/ptsl/engine.py
+++ b/ptsl/engine.py
@@ -1133,7 +1133,7 @@ class Engine:
         :returns: A dictionary containing the originId, instanceId,
         and parentId of the current opened session
         """
-        op = ops.CId_GetSessionsIDs()
+        op = ops.CId_GetSessionIDs()
         self.client.run(op)
 
         return op.response

--- a/ptsl/ops/__init__.py
+++ b/ptsl/ops/__init__.py
@@ -146,7 +146,7 @@ from .clear_all_memory_locations import CId_ClearAllMemoryLocations
 
 # Pro Tools 2024.3
 
-from .get_session_ids import CId_GetSessionsIDs
+from .get_session_ids import CId_GetSessionIDs
 
 # Pro Tools 2025.6
 

--- a/ptsl/ops/get_session_ids.py
+++ b/ptsl/ops/get_session_ids.py
@@ -1,5 +1,5 @@
 from ptsl.ops import Operation
 
 
-class CId_GetSessionsIDs(Operation):
+class CId_GetSessionIDs(Operation):
     pass


### PR DESCRIPTION
## Summary
Class `CId_GetSessionsIDs` (plural Sessions) does not match the PTSL proto enum definition `CId_GetSessionIDs` (singular Session), causing import/usage errors.

## Fix
Rename `CId_GetSessionsIDs` → `CId_GetSessionIDs` in 3 files:
- `ptsl/ops/get_session_ids.py` — class name
- `ptsl/ops/__init__.py` — import statement  
- `ptsl/engine.py` — usage

## Verification
All other `CId_Get*` classes use singular `Session` (e.g. `CId_GetSessionName`, `CId_GetSessionPath`), confirming this is a typo.