### PR TITLE
Fix/edit memory location color index

### DIFF
--- a/ptsl/engine.py
+++ b/ptsl/engine.py
@@ -416,7 +416,7 @@ class Engine:
         :param MemoryLocationProperties general_properties: Location properties
         :param str comments: Comment field
         :param int color_index: Optional color index. If omitted, Pro Tools 
-            will cycle to the next color in it's palette rather than preserving 
+            will cycle to the next color in its palette rather than preserving 
             the existing color.
         """
         op = ops.CId_EditMemoryLocation(

--- a/ptsl/engine.py
+++ b/ptsl/engine.py
@@ -415,8 +415,8 @@ class Engine:
         :param MemoryLocationReference reference: Reference
         :param MemoryLocationProperties general_properties: Location properties
         :param str comments: Comment field
-        :param int color_index: Optional color index. If omitted, Pro Tools 
-            will cycle to the next color in its palette rather than preserving 
+        :param int color_index: Optional color index. If omitted, Pro Tools
+            will cycle to the next color in its palette rather than preserving
             the existing color.
         """
         op = ops.CId_EditMemoryLocation(

--- a/ptsl/engine.py
+++ b/ptsl/engine.py
@@ -400,7 +400,8 @@ class Engine:
                              time_properties: 'TimeProperties',
                              reference: 'MemoryLocationReference',
                              general_properties: 'MemoryLocationProperties',
-                             comments: str):
+                             comments: str,
+                             color_index: Optional[int] = None):
         """
         Edit a memory location.
 
@@ -414,6 +415,9 @@ class Engine:
         :param MemoryLocationReference reference: Reference
         :param MemoryLocationProperties general_properties: Location properties
         :param str comments: Comment field
+        :param int color_index: Optional color index. If omitted, Pro Tools 
+            will cycle to the next color in it's palette rather than preserving 
+            the existing color.
         """
         op = ops.CId_EditMemoryLocation(
             number=location_number,
@@ -423,7 +427,8 @@ class Engine:
             time_properties=time_properties,
             reference=reference,
             general_properties=general_properties,
-            comments=comments
+            comments=comments,
+            color_index=color_index
         )
 
         self.client.run(op)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -224,7 +224,7 @@ class TestEngine(TestCase):
                 self.assertIsNone(
                     engine.edit_memory_location(**test_fixture)
                 )
-                
+
     def test_edit_memory_location_with_color_index(self):
         with open_engine_with_mock_client() as engine:
             fixture = self.MARKER_LOCATION_FIXTURE[0].copy()
@@ -233,7 +233,7 @@ class TestEngine(TestCase):
             self.assertIsNone(
                 engine.edit_memory_location(**fixture)
             )
-            
+
     def test_get_memory_locations(self):
         fixture = pt.GetMemoryLocationsResponseBody(
             memory_locations=[

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -224,7 +224,16 @@ class TestEngine(TestCase):
                 self.assertIsNone(
                     engine.edit_memory_location(**test_fixture)
                 )
-
+                
+    def test_edit_memory_location_with_color_index(self):
+        with open_engine_with_mock_client() as engine:
+            fixture = self.MARKER_LOCATION_FIXTURE[0].copy()
+            fixture['location_number'] = fixture.pop('number')
+            fixture['color_index'] = 7
+            self.assertIsNone(
+                engine.edit_memory_location(**fixture)
+            )
+            
     def test_get_memory_locations(self):
         fixture = pt.GetMemoryLocationsResponseBody(
             memory_locations=[


### PR DESCRIPTION
**Issue**
Running 'edit_memory_location' would cycle the memory location color, rather than maintaining the original color.

**Fix**
PTSL.proto has support for 'color_index' as field 9, but was omitted in the python wrapper. Added 'color_index' parameter to Engine.edit_memory_location(), matching the existing pattern to support maintaining the color of the existing marker, or setting a new one. Defaults to 'none'. 

**Scope:**
_Bug fix_ | _New Feature_ 

